### PR TITLE
Dettach electron process on Windows

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,7 +7,6 @@ module.exports = (glob, options) => {
   let browserWindows = [];
   let opts = Object.assign({ignored: /node_modules|[\/\\]\./}, options);
   let watcher = chokidar.watch(glob, opts);
-  let isWin = /^win/.test(process.platform);
 
   /**
    * Callback function to be executed when any of the files
@@ -43,17 +42,13 @@ module.exports = (glob, options) => {
     let mainFile = path.join(appPath, config.main);
 
     chokidar.watch(mainFile).on('change', () => {
-	  // Detaching child is useful when in Windows to let child
-	  // live after the parent is killed
-	  if (isWin) {
-	    let child = proc.spawn(eXecutable, [appPath], {
-	      detached: true,
-		  stdio: 'inherit'
-	    });
-	    child.unref();
-	  } else {
-		  proc.spawn(eXecutable, [appPath]);
-	  }
+      // Detaching child is useful when in Windows to let child
+      // live after the parent is killed
+      let child = proc.spawn(eXecutable, [appPath], {
+        detached: true,
+        stdio: 'inherit'
+      });
+      child.unref();
       // Kamikaze!
       app.quit();
     });

--- a/main.js
+++ b/main.js
@@ -42,7 +42,9 @@ module.exports = (glob, options) => {
     let mainFile = path.join(appPath, config.main);
 
     chokidar.watch(mainFile).on('change', () => {
-      proc.spawn(eXecutable, [appPath]);
+      proc.spawn(eXecutable, [appPath], {
+	      detached: true
+      });
       // Kamikaze!
       app.quit();
     });

--- a/main.js
+++ b/main.js
@@ -43,7 +43,8 @@ module.exports = (glob, options) => {
 
     chokidar.watch(mainFile).on('change', () => {
       proc.spawn(eXecutable, [appPath], {
-	      detached: true
+        detached: true,
+        stdio: 'inherit',
       });
       // Kamikaze!
       app.quit();


### PR DESCRIPTION
On Windows 10, Node 6.3.0, Chromium 52.0.2743.82, Electron 1.3.1 the spawned process is attached unless "detached: true" is passed to proc.spawn().

On Windows, this causes the newly spawned electron process to be considered attached and killed along with the parent when app.quit() is called. This fixed for me on Windows. I couldn't test it on Linux or OS X.