### PR TITLE
Allow single page to be loaded on change

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,25 @@ require('electron-reload')(__dirname, {
 # API
 `electron_reload(paths, options)`
 * `paths`: a file, directory or glob pattern to watch
-* `options` (optional): [`chokidar`](https://github.com/paulmillr/chokidar) options plus `electron` property pointing to electron executables. (default: `{ignored: /node_modules|[\/\\]\./}`)
+* `options` (optional):  See [options](#options)
 
+# Options
+
+#### electron
+`string`  
+Path to electron
+
+#### singleURL
+`string`  
+If single url is passed, instead of reloading on change we load this url.  
+This is useful if you wrap Electron around an SPA that handles it's own routing.
+
+Everything else is passed to [`chokidar`](https://github.com/paulmillr/chokidar) with the default addition of
+```js
+{
+  ignored: /node_modules|[\/\\]\./
+}
+```
 
 # Why this module?
 Simply put, I was tired and confused by all other available modules which are so complicated\* for such an uncomplicated task!

--- a/main.js
+++ b/main.js
@@ -7,8 +7,8 @@ const path = require('path');
 module.exports = (glob, options) => {
   options = options || {};
   let browserWindows = [];
-  let opts = Object.assign({ignored: /node_modules|[\/\\]\./}, options);
-  let watcher = chokidar.watch(glob, opts);
+  let chokidarOptions = Object.assign({ignored: /node_modules|[\/\\]\./}, options);
+  let watcher = chokidar.watch(glob, chokidarOptions);
 
   /**
    * Callback function to be executed when any of the files

--- a/main.js
+++ b/main.js
@@ -6,6 +6,10 @@ const path = require('path');
 
 module.exports = (glob, options) => {
   options = options || {};
+  
+  let eXecutable = options.electron;
+  delete options.electron;
+
   let browserWindows = [];
   let chokidarOptions = Object.assign({ignored: /node_modules|[\/\\]\./}, options);
   let watcher = chokidar.watch(glob, chokidarOptions);
@@ -33,7 +37,6 @@ module.exports = (glob, options) => {
 
   // Preparing hard reset if electron executable is given in options
   // A hard reset is only done when the main file has changed
-  let eXecutable = options.electron;
   if(eXecutable && fs.existsSync(eXecutable)) {
     let appPath = app.getAppPath();
     // eslint-disable-line

--- a/main.js
+++ b/main.js
@@ -6,9 +6,12 @@ const path = require('path');
 
 module.exports = (glob, options) => {
   options = options || {};
-  
+
   let eXecutable = options.electron;
   delete options.electron;
+
+  let singleURL = options.singleURL;
+  delete options.singleURL;
 
   let browserWindows = [];
   let chokidarOptions = Object.assign({ignored: /node_modules|[\/\\]\./}, options);
@@ -20,7 +23,11 @@ module.exports = (glob, options) => {
    */
   let onChange = () => {
     browserWindows.forEach((bw) => {
-      bw.webContents.reloadIgnoringCache();
+      if(singleURL){
+        bw.loadURL(singleURL);
+      } else {
+        bw.webContents.reloadIgnoringCache();
+      }
     });
   };
 


### PR DESCRIPTION
This adds an option to pass a single url to the watcher that is loaded whenever a change is detected instead of doing a reload.

This is very useful when you run some sort of framework that does routing by itself instead of relying on manual routing.
