### PR TITLE
Changes method used during hard reset from 'app.quit()` to `app.exit()`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ require('electron-reload')(__dirname, {
 });
 ```
 
+If your app overrides some of the default `quit` or `close` actions (e.g. closing the last app window hides the window instead of quitting the app) then the default `electron-reload` hard restart could leave you with multiple instances of your app running. In these cases you can change the default hard restart action from `app.quit()` to `app.exit()` by specifying the hard reset method in the electron-reload options:
+
+```js
+const path = require('path')
+
+require('electron-reload')(__dirname, {
+  electron: path.join(__dirname, 'node_modules', '.bin', 'electron'),
+  hardResetMethod: 'exit'
+});
+```
+
 # API
 `electron_reload(paths, options)`
 * `paths`: a file, directory or glob pattern to watch

--- a/main.js
+++ b/main.js
@@ -49,7 +49,15 @@ module.exports = (glob, options) => {
       });
       child.unref();
       // Kamikaze!
-      app.exit();
+
+      // In cases where an app overrides the default closing or quiting actions
+      // firing an `app.quit()` may not actually quit the app. In these cases
+      // you can use `app.exit()` to gracefully close the app.
+      if(opts.hardResetMethod === 'exit'){
+          app.exit();
+      } else {
+          app.quit();
+      }
     });
   } else {
     console.log('Electron could not be found. No hard resets for you!');

--- a/main.js
+++ b/main.js
@@ -49,7 +49,7 @@ module.exports = (glob, options) => {
       });
       child.unref();
       // Kamikaze!
-      app.quit();
+      app.exit();
     });
   } else {
     console.log('Electron could not be found. No hard resets for you!');


### PR DESCRIPTION
If your app does something to prevent the normal closing of the app (for example, preventing the default action of the browser window `close` event so that you can instead hide the window and still have access to it) using `app.quit()` during a hard reset will result in multiple instances of the app running. 

E.g. in my app in the main process I'm using the following hook to hide the browser window instead of closing it: 

```
    win.on('close', event => {
        if(!app.isQuitting){
            event.preventDefault()
            win.hide()
        }
        return false
    })
```

Which results in this:

![multipleinstances](https://cloud.githubusercontent.com/assets/2437424/20607696/12288e5c-b240-11e6-9e7d-53597303aa2b.gif)

If you use [`app.exit()`](http://electron.atom.io/docs/api/app/#appexitexitcode) in the hard reset logic, the app will be closed without emitting events that the developer could have hooked into. 

Small but helpful change. 

Thanks for building this utility! It's been a real time and sanity saver while I build out my app and it's become a must have dev dependency for any future electron app I build. 