### PR TITLE
main file reference changed

### DIFF
--- a/main.js
+++ b/main.js
@@ -12,7 +12,7 @@ module.exports = (glob, options) => {
   // only effective when the process is restarted (hard reset)
   let appPath = app.getAppPath()
   let config = require(path.join(appPath, 'package.json'))
-  let mainFile = path.join(appPath, config.main)
+  let mainFile = path.join(glob, config.main)
 
   // Watch everything but the node_modules folder and main file
   // main file changes are only effective if hard reset is possible


### PR DESCRIPTION
Isn't the main.js file usually in the `__dirname` folder instead of where the executable resides?

For my setup the original code never triggered a restart because it was referencing to a nonexisting file.
