### PR TITLE
Allow command line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,15 @@ require('electron-reload')(__dirname, {
 # API
 `electron_reload(paths, options)`
 * `paths`: a file, directory or glob pattern to watch
-* `options` (optional): [`chokidar`](https://github.com/paulmillr/chokidar) options plus `electron` property pointing to electron executables. (default: `{ignored: /node_modules|[\/\\]\./}`)
+* `options` (optional) containing: 
+
+   [`chokidar`](https://github.com/paulmillr/chokidar) options
+   
+   `electron` property pointing to electron executables.
+
+   `argv` string array with command line options passed to the executed Electron app. Only used when hard resetting.
+
+`options` will default to `{ignored: /node_modules|[\/\\]\./, argv: []}`.
 
 
 # Why this module?

--- a/main.js
+++ b/main.js
@@ -18,11 +18,13 @@ const ignoredPaths = [mainFile, /node_modules|[/\\]\./]
  * @param {String} hardResetMethod method to restart electron
  * @returns {Function} handler to pass to chokidar
  */
-const createHardresetHandler = (eXecutable, hardResetMethod) =>
+const createHardresetHandler = (eXecutable, hardResetMethod, argv) =>
   () => {
     // Detaching child is useful when in Windows to let child
     // live after the parent is killed
-    let child = spawn(eXecutable, [appPath], {
+    let args = (argv || []).concat([appPath]);
+    console.log("new args", args);
+    let child = spawn(eXecutable, args, {
       detached: true,
       stdio: 'inherit'
     })
@@ -73,9 +75,10 @@ module.exports = (glob, options = {}) => {
 
   // Preparing hard reset if electron executable is given in options
   // A hard reset is only done when the main file has changed
+  console.log("options", options);
   let eXecutable = options.electron
   if (eXecutable && fs.existsSync(eXecutable)) {
-    chokidar.watch(mainFile).once('change', createHardresetHandler(eXecutable, options.hardResetMethod))
+    chokidar.watch(mainFile).once('change', createHardresetHandler(eXecutable, options.hardResetMethod, options.argv))
   } else {
     console.log('Electron could not be found. No hard resets for you!')
   }

--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
-const {app} = require('electron')
+const { app } = require('electron')
 const chokidar = require('chokidar')
 const fs = require('fs')
-const {spawn} = require('child_process')
+const { spawn } = require('child_process')
 const path = require('path')
 
 // Main file poses a special case, as its changes are
@@ -22,7 +22,7 @@ const createHardresetHandler = (eXecutable, hardResetMethod, argv) =>
   () => {
     // Detaching child is useful when in Windows to let child
     // live after the parent is killed
-    let args = (argv || []).concat([appPath]);
+    let args = (argv || []).concat([appPath])
     let child = spawn(eXecutable, args, {
       detached: true,
       stdio: 'inherit'
@@ -49,7 +49,7 @@ const createHardresetHandler = (eXecutable, hardResetMethod, argv) =>
 const createWatcher = (glob, options = {}) => {
   // Watch everything but the node_modules folder and main file
   // main file changes are only effective if hard reset is possible
-  let opts = Object.assign({ignored: ignoredPaths}, options)
+  let opts = Object.assign({ ignored: ignoredPaths }, options)
   return chokidar.watch(glob, opts)
 }
 

--- a/main.js
+++ b/main.js
@@ -23,7 +23,6 @@ const createHardresetHandler = (eXecutable, hardResetMethod, argv) =>
     // Detaching child is useful when in Windows to let child
     // live after the parent is killed
     let args = (argv || []).concat([appPath]);
-    console.log("new args", args);
     let child = spawn(eXecutable, args, {
       detached: true,
       stdio: 'inherit'
@@ -75,7 +74,6 @@ module.exports = (glob, options = {}) => {
 
   // Preparing hard reset if electron executable is given in options
   // A hard reset is only done when the main file has changed
-  console.log("options", options);
   let eXecutable = options.electron
   if (eXecutable && fs.existsSync(eXecutable)) {
     chokidar.watch(mainFile).once('change', createHardresetHandler(eXecutable, options.hardResetMethod, options.argv))


### PR DESCRIPTION
This PR allows users to pass command line arguments when hard resetting the Electron app. This is useful in certain scenarios where you the Electron app is started with extra command line arguments. In such a scenario the arguments should be retained between start ups.