### PR TITLE
Fix typo in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ require('electron-reload')(__dirname);
 app.on('ready', () {
   let mainWindow = new BrowserWindow({width: 800, height: 600});
 
-  mainWindow.loadUrl(`file://${__dirname}/index.html`);
+  mainWindow.loadURL(`file://${__dirname}/index.html`);
   // the rest...
 });
 ```


### PR DESCRIPTION
Trying out electron & this lib for this first time, build issue unless I capitalize URL.