### PR TITLE
Added missing arrow syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ const {app, BrowserWindow} = require('electron');
 require('electron-reload')(__dirname);
 
 // Standard stuff
-app.on('ready', () {
+app.on('ready', () => {
   let mainWindow = new BrowserWindow({width: 800, height: 600});
 
   mainWindow.loadUrl(`file://${__dirname}/index.html`);


### PR DESCRIPTION
JavaScript code block was missing arrow ( => ) for callback function

# A quick note for PRs
  * PRs are strictly limited to technical changes to the source code (e.g., please no PRs for changes to the documentation)
  * Before submitting a PR, please consult the issues, if you don't find a matching issue, open a new one and let's discuss the changes first
  * *Always* refer to the corresponding issue addressed by your PR in the last commit (e.g., `fixes #12`)