### PR TITLE
Allow mainFile to be configured as an option

### DIFF
--- a/main.js
+++ b/main.js
@@ -9,7 +9,7 @@ const ignoredPaths = /node_modules|[/\\]\./
 // only effective when the process is restarted (hard reset)
 // We assume that electron-reload is required by the main
 // file of the electron application
-const mainFile = module.parent.filename
+const assumedMainFile = module.parent && module.parent.filename
 
 /**
  * Creates a callback for hard resets.
@@ -42,6 +42,7 @@ const createHardresetHandler = (eXecutable, hardResetMethod, argv) =>
 
 module.exports = (glob, options = {}) => {
   const browserWindows = []
+  const mainFile = options.mainFile || assumedMainFile
   const watcher = chokidar.watch(glob, Object.assign({ ignored: [ignoredPaths, mainFile] }, options))
 
   // Callback function to be executed:


### PR DESCRIPTION
This issue is related to issue [#66], but in my case setting `__dirname: false` in the webpack config doesn't work.  From what I've read, the issue is because I'm using a config target of `electron-main`, which I want to keep.

My changes does two things:

* Don't error out if `module.parent` is undefined.
* Allow `mainFile` as an option to the reload function.
module.parent.filename doesn't evaluate properly when using webpack.
