### PR TITLE
feat: allow array type glob

### DIFF
--- a/types/main.d.ts
+++ b/types/main.d.ts
@@ -28,4 +28,4 @@ export interface ElectronReloadOptions extends WatchOptions {
     forceHardReset?: boolean
 }
 
-export default function electronReload(glob: string, options: ElectronReloadOptions) : void;
+export default function electronReload(glob: string | ReadonlyArray<string>, options: ElectronReloadOptions) : void;


### PR DESCRIPTION
The type definition of `glob` does not allow array type, but `chokidar` support it.